### PR TITLE
Add render caching

### DIFF
--- a/opal/clearwater/cached_render.rb
+++ b/opal/clearwater/cached_render.rb
@@ -1,0 +1,15 @@
+module Clearwater
+  module CachedRender
+    def cached_render
+      if !@cached_render || should_render?
+        @cached_render = render
+      else
+        @cached_render
+      end
+    end
+
+    def should_render?
+      false
+    end
+  end
+end

--- a/opal/clearwater/cached_render.rb
+++ b/opal/clearwater/cached_render.rb
@@ -2,7 +2,7 @@ module Clearwater
   module CachedRender
     def cached_render
       if !@cached_render || should_render?
-        @cached_render = render
+        @cached_render = sanitize_content(render)
       else
         @cached_render
       end


### PR DESCRIPTION
With this PR, if a component doesn't need to be rerendered, you can include the `Clearwater::CachedRender` mixin and the value will be cached on the component. If you do need to override the cache, you can override `should_render?` and have it return an expression which, when truthy, will expire the cache.

This PR fixes #15.