### PR TITLE
Use virtual-dom thunks for CachedRender

### DIFF
--- a/opal/clearwater/cached_render.rb
+++ b/opal/clearwater/cached_render.rb
@@ -1,14 +1,23 @@
 module Clearwater
   module CachedRender
-    def cached_render
-      if !defined?(@cached_render) || should_render?
-        @cached_render = sanitize_content(render)
-      else
-        @cached_render
-      end
+
+    def self.included base
+      %x{
+        Opal.defn(base, 'type', 'Thunk');
+        Opal.defn(base, 'render', function(prev) {
+          var self = this;
+          var should_render;
+
+          if(prev && prev.vnode && #{!should_render?(`prev`)}) {
+            return prev.vnode;
+          } else {
+            return #{sanitize_content(render)};
+          }
+        });
+      }
     end
 
-    def should_render?
+    def should_render? _
       false
     end
   end

--- a/opal/clearwater/component.rb
+++ b/opal/clearwater/component.rb
@@ -186,7 +186,7 @@ module Clearwater
 
     def sanitize_content content
       %x{
-        if(content.$$class) {
+        if(content && content.$$class) {
           if(content.$$class === Opal.Array) {
             return #{content.map { |c| `self.$sanitize_content(c)` }};
           } else if(content === Opal.nil) {
@@ -195,8 +195,8 @@ module Clearwater
             var cached_render = content.$cached_render;
             var render = content.$render;
 
-            if(cached_render && !cached_render.$$stub) {
-              return content.$cached_render();
+            if(content.type === 'Thunk' && typeof(content.render) === 'function') {
+              return content;
             } else if(render && !render.$$stub) {
               return self.$sanitize_content(content.$render());
             } else {

--- a/spec/clearwater/cached_render_spec.rb
+++ b/spec/clearwater/cached_render_spec.rb
@@ -21,19 +21,26 @@ module Clearwater
     let(:component) { component_class.new(value) }
 
     it 'memoizes the return value of render' do
-      expect(value).to receive(:to_s).once
+      component = component()
 
-      2.times { component.cached_render }
+      expect(value).to receive(:to_s)
+      %x{ component.render(component) }
+
+      component.instance_exec { @vnode = VirtualDOM.node('div', 'howdy') }
+      expect(value).not_to receive(:to_s)
+
+      2.times { `component.render(component)` }
     end
 
     it 'uses should_render? to determine whether to call render again' do
+      component = component()
       def component.should_render?
         true
       end
 
       expect(value).to receive(:to_s).twice
 
-      2.times { component.cached_render }
+      2.times { `component.render(component)` }
     end
   end
 end


### PR DESCRIPTION
Currently, in order to use `CachedRender` in any useful way, the parent component must know that the child caches itself and must reuse the instance of the child component on subsequent renders. For example, consider a parent component `Foo` rendering a child component `Bar` (which includes the `CachedRender` mixin):

```ruby
class Foo
  include Clearwater::Component

  def render
    div(bar)
  end

  # Cache the Bar instance, which caches its render
  def bar
    @bar ||= Bar.new
  end
end
```

Using `virtual-dom`'s implementation of [Thunks](https://github.com/Matt-Esch/virtual-dom/blob/master/docs/thunk.md), we can pass along an entirely new `Bar` instance:

```ruby
class Foo
  include Clearwater::Component

  def render
    div(Bar.new)
  end
end
```

This way, the parent component doesn't have to care whether the child caches itself. It can just keep passing new instances.

There are a couple reasons I opened this PR:

- This introduces a breaking change
- The version of caching on `master` is sometimes a better option

## Breaking change

This PR changes how `CachedRender#should_render?` works. With this PR, `should_render?` always compares two instances of the same component. Previously, you might use that method to compare a piece of state on the current instance (saved in the previous render) to a new value stored in app state. For example:

```ruby
class Bar
  include Clearwater::Component
  include Clearwater::CachedRender

  attr_reader :name

  def initialize name
    @name = name
  end

  def should_render? prev
    prev.name != name
  end
end
```

And when I say that you're always comparing two instances, that means that if you pass the same `CachedRender` instance in on the next render (the way it must currently be done on `master`), `should_render?` won't be called at all. There's nothing we can do about that since it's an optimization within `virtual-dom`.

The good news is that this encourages immutable components to be passed in from the bottom up. You would just pass all the objects the component needs for rendering into the initializer (or pull it in from your app state, assuming that uses [immutable data structures](https://github.com/clearwater-rb/grand_central)), which is basically what React encourages with the mantra of "prefer props over state".

## Not always better

When you store the same instance of a component whose actual render value is cached, you can navigate away and come back and you won't need to regenerate the virtual-DOM nodes. They're already there and you can just reuse that cached value. 

The tradeoff is that that takes up extra RAM. Using the technique in this PR will free up that RAM when you navigate away, but will keep the cache warm while the component is on screen.

Another tradeoff is that with this new method, the fresh instance may need to copy state from the previous version so it can be used in the _next_ render, as well. This is something that isn't necessary in the current `CachedRender` implementation; since you're using the same component instance every time. However, I can only think of a few rare instances this would be necessary.