### PR TITLE
Add BlackBoxNode

### DIFF
--- a/opal/clearwater/black_box_node.rb
+++ b/opal/clearwater/black_box_node.rb
@@ -1,0 +1,67 @@
+require 'bowser/element'
+require 'clearwater/virtual_dom'
+
+module Clearwater
+  module BlackBoxNode
+    def node
+      VirtualDOM.node :div
+    end
+
+    def mount node
+    end
+
+    def update previous, node
+    end
+
+    def unmount node
+    end
+
+    def render
+      Renderable.new(self)
+    end
+
+    class Renderable
+      def initialize delegate
+        @delegate = delegate
+      end
+
+      def wrap node
+        Bowser::Element.new(node)
+      end
+
+      def create_element
+        wrap(VirtualDOM.create_element(@delegate.node))
+      end
+
+      %x{
+        // Use the virtual-dom Widget type
+        Opal.defn(self, 'type', 'Widget');
+
+        // virtual-dom Widget init hook. Must return a real DOM node.
+        // We call the Ruby-land #mount method so we can define hooks for this
+        // in Ruby instead of requiring users to drop down to JS.
+        Opal.defn(self, 'init', function() {
+          var self = this;
+          var node = #{create_element};
+          #{@delegate.mount(`node`)};
+          return node.native;
+        });
+
+        // virtual-dom update hook
+        //   previous: the instance of this object used in the previous render
+        //   node: a Bowser-wrapped version of the DOM node
+        Opal.defn(self, 'update', function(previous, node) {
+          var self = this;
+          #{@delegate.update(`previous.delegate`, wrap(`node`))};
+        });
+
+        // virtual-dom destroy hook
+        //   node: Bowser-wrapped version of the DOM node
+        Opal.defn(self, 'destroy', function(node) {
+          var self = this;
+          #{@delegate.unmount(wrap(`node`))};
+        });
+      }
+    end
+  end
+end

--- a/spec/clearwater/black_box_node_spec.rb
+++ b/spec/clearwater/black_box_node_spec.rb
@@ -1,0 +1,64 @@
+require 'clearwater/black_box_node'
+
+module Clearwater
+  describe BlackBoxNode do
+    let(:object) {
+      Class.new do
+        include Clearwater::BlackBoxNode
+
+        attr_reader :last_update
+
+        def node
+          VirtualDOM.node :span, { id: 'foo' }, ['hi']
+        end
+
+        def mount node
+          @mounted = true
+        end
+
+        def update
+          @last_update = Time.now
+        end
+
+        def unmount
+          @mounted = false
+        end
+
+        def mounted?
+          !!@mounted
+        end
+      end.new
+    }
+    let(:renderable) { BlackBoxNode::Renderable.new(object) }
+
+    it 'has the special type of "Widget"' do
+      r = renderable
+      expect(`r.type`).to eq 'Widget'
+    end
+
+    it 'uses the delegate node to render into the DOM' do
+      r = renderable
+      expect(`#{renderable.create_element}.native.outerHTML`).to eq '<span id="foo">hi</span>'
+    end
+
+    it 'calls mount when inserted into the DOM' do
+      r = renderable
+      `r.init()`
+      expect(object).to be_mounted
+    end
+
+    it 'calls unmount when removed from the DOM' do
+      r = renderable
+      `r.init()`
+      `r.destroy()`
+      expect(object).not_to be_mounted
+    end
+
+    it 'calls update when updated in the DOM' do
+      r = renderable
+      `r.update({})`
+
+      expect(object.last_update).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
A `BlackBoxNode` is a node in the tree that manages its own DOM node. The virtual-dom engine stays out of it and just tells it when the various DOM CRUD methods need to be run.

For example:

```ruby
class Foo
  include Clearwater::BlackBoxNode

  def node
    Clearwater::Component.span({ id: 'foo' }, 'Foo')
  end

  def mount(node)
    puts "Hello #{node}"
  end

  def update(previous, node)
    puts "Updating #{node} from #{previous} to #{self}"
  end

  def unmount(node)
    puts "Unmounting #{node}"
  end
end
```

An instance of `Foo` will output to the console:
- `Hello #<Bowser::Element:0x20a>` when it is rendered into the DOM
  - the node's initial HTML will be `<span id="foo">Foo</span>` since we declared it in the `node` method to be that type of virtual-DOM node
- `Updating #<Bowser::Element:0x22a> from #<Foo:0x204> to #<Foo:0x226>` whenever it is re-rendered
  - the `previous` argument is the instance of `Foo` that was encountered on the previous render
- `Unmounting #<Bowser::Element:0x28c>` when the DOM diff/patch process determines that node has been removed from the DOM

This is useful for things like Charts.js or Google Maps, where you have to render their content into an existing node. Since the `mount` method receives the node, you don't have to do anything like `document.getElementById('foo')` (which would trigger a page reflow) to get a reference to it. Note: this is a `Bowser::Element` instance, so to get the native element, you have to use `node.native`.

Also notable is that because we encourage passing new instances of every component each time the app is rendered, we won't get the same `Foo` instance every time, so state generated in `mount` would have to be copied into the new `Foo` in the `update` method. For the most part, it's recommended not to generate state in `mount`, but pass it into `initialize` instead.