### PR TITLE
Add DOMReference class

### DIFF
--- a/opal/clearwater/dom_reference.rb
+++ b/opal/clearwater/dom_reference.rb
@@ -1,0 +1,30 @@
+module Clearwater
+  class DOMReference
+    def mount node, previous
+      @node = node
+    end
+
+    def unmount node, previous
+    end
+
+    def method_missing *args, &block
+      @node.public_send *args, &block
+    end
+
+    def wrap node
+      Bowser::Element.new(node)
+    end
+
+    %x{
+      Opal.defn(self, 'hook', function(node, name, previous) {
+        var self = this;
+        #{mount(wrap(`node`), `previous`)};
+      });
+
+      Opal.defn(self, 'unhook', function(node, name, previous) {
+        var self = this;
+        #{unmount(wrap(`node`), `previous`)};
+      });
+    }
+  end
+end

--- a/spec/clearwater/dom_reference_spec.rb
+++ b/spec/clearwater/dom_reference_spec.rb
@@ -1,0 +1,15 @@
+require 'clearwater/dom_reference'
+
+module Clearwater
+  describe DOMReference do
+    let(:ref) { DOMReference.new }
+
+    it 'delegates to the DOM node passed in on mount' do
+      r = ref
+
+      `r.hook({ value: 'hi' })`
+
+      expect(r.value).to eq 'hi'
+    end
+  end
+end


### PR DESCRIPTION
A `DOMReference` can be used as a property of a virtual-DOM node to get a reference to the rendered DOM node.

Example:

```ruby
class LoginForm
  include Clearwater::Component

  def initialize
    # These DOMReference objects are initially empty, but will be populated
    # when they are mounted into the DOM
    @email_node = Clearwater::DOMReference.new
    @password_node = Clearwater::DOMReference.new
  end

  def render
    form({ onsubmit: method(:submit) }, [
      # Note the `ref` attributes. The name of the attribute doesn't matter.
      input(type: :email, ref: @email_node),
      input(type: :password, ref: @password_node),
      input(type: :submit, value: 'Login'),
    ])
  end

  def submit(event)
    event.prevent

    # The values of the rendered nodes
    email = @email_node.value
    password = @password_node.value

    Bowser::HTTP.upload('/api/session', { email: email, password: password }).then do
      Router.navigate_to '/'
    end
  end
end
```