### PR TITLE
improve svg support

### DIFF
--- a/opal/clearwater/component.rb
+++ b/opal/clearwater/component.rb
@@ -122,12 +122,12 @@ module Clearwater
       router.params
     end
 
-    def self.sanitize_attributes attributes
+    def self.sanitize_attributes attributes, convert_class_key = true
       return attributes unless attributes.is_a? Hash
 
       # Allow specifying `class` instead of `class_name`.
       # Note: `class_name` is still allowed
-      if attributes.key? :class
+      if convert_class_key && attributes.key?(:class)
         if attributes.key? :class_name
           warn "You have both `class` and `class_name` attributes for this " +
             "element. `class` takes precedence: #{attributes}"

--- a/opal/clearwater/svg_component.rb
+++ b/opal/clearwater/svg_component.rb
@@ -103,7 +103,7 @@ module Clearwater
 
       VirtualDOM.svg(
         tag_name,
-        Component.sanitize_attributes(attributes),
+        Component.sanitize_attributes(attributes, false),
         Component.sanitize_content(content)
       )
     end

--- a/opal/clearwater/virtual_dom.rb
+++ b/opal/clearwater/virtual_dom.rb
@@ -11,7 +11,7 @@ module VirtualDOM
     %x{
       return virtualDom.svg(
         tag_name,
-        #{HashUtils.camelize_keys(attributes).to_n},
+        #{HashUtils.underlinize_keys(attributes).to_n},
         #{sanitize_content(content)}
       );
     }
@@ -93,5 +93,23 @@ module VirtualDOM
 
       camelized
     end
+  end
+
+  def self.underlinize_keys(hash)
+    return hash unless hash.is_a? Hash
+
+    underlinized = {}
+    hash.each do |k, v|
+      key = `k.replace(/_/g, '-')`
+      value = if v.class == Hash
+                underlinize_keys(v)
+              else
+                v
+              end
+
+      underlinized[key] = value
+    end
+
+    underlinized
   end
 end

--- a/opal/clearwater/virtual_dom.rb
+++ b/opal/clearwater/virtual_dom.rb
@@ -11,7 +11,7 @@ module VirtualDOM
     %x{
       return virtualDom.svg(
         tag_name,
-        #{HashUtils.midlinize_keys(attributes).to_n},
+        #{HashUtils.camelize_keys(attributes).to_n},
         #{sanitize_content(content)}
       );
     }
@@ -92,24 +92,6 @@ module VirtualDOM
       end
 
       camelized
-    end
-
-    def self.midlinize_keys(hash)
-      return hash unless hash.is_a? Hash
-
-      midlinized = {}
-      hash.each do |k, v|
-        key = `k.replace(/_/g, '-')`
-        value = if v.class == Hash
-                  midlinize_keys(v)
-                else
-                  v
-                end
-
-        midlinized[key] = value
-      end
-
-      midlinized
     end
   end
 end

--- a/opal/clearwater/virtual_dom.rb
+++ b/opal/clearwater/virtual_dom.rb
@@ -11,7 +11,7 @@ module VirtualDOM
     %x{
       return virtualDom.svg(
         tag_name,
-        #{HashUtils.underlinize_keys(attributes).to_n},
+        #{HashUtils.midlinize_keys(attributes).to_n},
         #{sanitize_content(content)}
       );
     }
@@ -94,22 +94,22 @@ module VirtualDOM
       camelized
     end
 
-    def self.underlinize_keys(hash)
+    def self.midlinize_keys(hash)
       return hash unless hash.is_a? Hash
 
-      underlinized = {}
+      midlinized = {}
       hash.each do |k, v|
         key = `k.replace(/_/g, '-')`
         value = if v.class == Hash
-                  underlinize_keys(v)
+                  midlinize_keys(v)
                 else
                   v
                 end
 
-        underlinized[key] = value
+        midlinized[key] = value
       end
 
-      underlinized
+      midlinized
     end
   end
 end

--- a/opal/clearwater/virtual_dom.rb
+++ b/opal/clearwater/virtual_dom.rb
@@ -93,23 +93,23 @@ module VirtualDOM
 
       camelized
     end
-  end
 
-  def self.underlinize_keys(hash)
-    return hash unless hash.is_a? Hash
+    def self.underlinize_keys(hash)
+      return hash unless hash.is_a? Hash
 
-    underlinized = {}
-    hash.each do |k, v|
-      key = `k.replace(/_/g, '-')`
-      value = if v.class == Hash
-                underlinize_keys(v)
-              else
-                v
-              end
+      underlinized = {}
+      hash.each do |k, v|
+        key = `k.replace(/_/g, '-')`
+        value = if v.class == Hash
+                  underlinize_keys(v)
+                else
+                  v
+                end
 
-      underlinized[key] = value
+        underlinized[key] = value
+      end
+
+      underlinized
     end
-
-    underlinized
   end
 end


### PR DESCRIPTION
`
svg(class: 'mysvg', markerHeight: 10, marker_end: "url(#arrow)")
`
get 
`
<svg class='mysvg' markerHeight=10 marker-end="url(#arrow)" ></svg>
`
Is there better solution for property name convert?