### PR TITLE
Allow nested CachedRenders

### DIFF
--- a/opal/clearwater/cached_render.rb
+++ b/opal/clearwater/cached_render.rb
@@ -11,7 +11,13 @@ module Clearwater
           if(prev && prev.vnode && #{!should_render?(`prev`)}) {
             return prev.vnode;
           } else {
-            return #{Component.sanitize_content(render)};
+            var content = #{Component.sanitize_content(render)};
+
+            while(content && content.type == 'Thunk' && content.render) {
+              content = #{Component.sanitize_content(`content.render(prev)`)};
+            }
+
+            return content;
           }
         });
       }

--- a/spec-opal/clearwater/cached_render_spec.rb
+++ b/spec-opal/clearwater/cached_render_spec.rb
@@ -42,5 +42,27 @@ module Clearwater
 
       2.times { `component.render(component)` }
     end
+
+    it 'allows nested CachedRender renders' do
+      foo = Class.new do
+        include Clearwater::Component
+        include Clearwater::CachedRender
+
+        def render
+          'hi'
+        end
+      end
+
+      bar = Class.new do
+        include Clearwater::Component
+        include Clearwater::CachedRender
+
+        define_method :render do
+          foo.new
+        end
+      end.new
+
+      expect(`bar.render()`).to eq 'hi'
+    end
   end
 end


### PR DESCRIPTION
This fixes #45 by recursively invoking the cache checker if needed, but I want to have a discussion surrounding it before it gets merged in. Specifically, two things I want to discuss:

1. Is this a good idea?
  1. I have no idea what the maintenance burden of this might be. It will probably be trivial, but still worth having a conversation.
  1. It will probably overflow the stack when someone inevitably returns `self` from `render`. Do we care?
1. What are the performance implications?
  1. If I'm being completely honest, this is my main concern. I haven't benchmarked this and that makes me nervous. :-)
  1. The most common case will be that the `while` loop is not invoked, but the conditional, while pretty cheap, isn't free and is potentially invoked thousands of times during a render. Even cheap things can get expensive in loops.
  1. `CachedRender` is intended to keep our apps fast. If it adds significant overhead, we should decide whether to support this use case.

cc @balmoral