### PR TITLE
Add routing transition hooks

### DIFF
--- a/shared/clearwater/router.rb
+++ b/shared/clearwater/router.rb
@@ -100,6 +100,23 @@ module Clearwater
     end
 
     def set_outlets targets=targets_for_path(current_path)
+      @old_targets = @targets || []
+      @targets = targets
+      navigating_from = @old_targets - @targets
+      navigating_to = @targets - @old_targets
+
+      navigating_from.each do |target|
+        if target.respond_to? :route_transition_away
+          target.route_transition_away
+        end
+      end
+
+      navigating_to.each do |target|
+        if target.respond_to? :route_transition_to
+          target.route_transition_to
+        end
+      end
+
       if targets.any?
         (targets.count).times do |index|
           targets[index].outlet = targets[index + 1]

--- a/shared/clearwater/router.rb
+++ b/shared/clearwater/router.rb
@@ -106,14 +106,14 @@ module Clearwater
       navigating_to = @targets - @old_targets
 
       navigating_from.each do |target|
-        if target.respond_to? :route_transition_away
-          target.route_transition_away
+        if target.respond_to? :on_route_from
+          target.on_route_from
         end
       end
 
       navigating_to.each do |target|
-        if target.respond_to? :route_transition_to
-          target.route_transition_to
+        if target.respond_to? :on_route_to
+          target.on_route_to
         end
       end
 

--- a/spec-opal/clearwater/router_spec.rb
+++ b/spec-opal/clearwater/router_spec.rb
@@ -61,5 +61,44 @@ module Clearwater
 
       expect(router.params('/clearwater/articles/123')).to eq({ article_id: '123' })
     end
+
+    it 'calls route transitions on routing targets' do
+      router = Router.new
+      component_class = Class.new do
+        include Clearwater::Component
+
+        attr_reader :transition_to, :transition_away
+
+        def initialize
+          @transition_to = 0
+          @transition_away = 0
+        end
+
+        def route_transition_to
+          @transition_to += 1
+        end
+
+        def route_transition_away
+          @transition_away += 1
+        end
+      end
+
+      targets = [
+        component_class.new,
+        component_class.new,
+        component_class.new,
+      ]
+      router.set_outlets [targets[0], targets[1]]
+      router.set_outlets [targets[0], targets[2]]
+      router.set_outlets [targets[0], targets[1]]
+      router.set_outlets [targets[0]]
+
+      expect(targets[0].transition_to).to eq 1
+      expect(targets[0].transition_away).to eq 0
+      expect(targets[1].transition_to).to eq 2
+      expect(targets[1].transition_away).to eq 2
+      expect(targets[2].transition_to).to eq 1
+      expect(targets[2].transition_away).to eq 1
+    end
   end
 end

--- a/spec-opal/clearwater/router_spec.rb
+++ b/spec-opal/clearwater/router_spec.rb
@@ -74,11 +74,11 @@ module Clearwater
           @transition_away = 0
         end
 
-        def route_transition_to
+        def on_route_to
           @transition_to += 1
         end
 
-        def route_transition_away
+        def on_route_from
           @transition_away += 1
         end
       end


### PR DESCRIPTION
Fixes #51.

I'm not sure if this is an ideal solution, but it doesn't seem bad. It occurs within a method that does mutation already (and whose name implies it), so I think it's reasonable to set ivars in there — especially ones that aren't used anywhere else. I'm not sure, though.

I'm also not too keen on those method names (`route_transition_to` / `route_transition_away`), so if anyone has any ideas, please feel free to make suggestions.