### PR TITLE
Add CachedRender wrapper

### DIFF
--- a/opal/clearwater/cached_render.rb
+++ b/opal/clearwater/cached_render.rb
@@ -4,27 +4,16 @@ module Clearwater
   module CachedRender
     def self.included base
       %x{
-        Opal.defn(self, 'type', 'Thunk');
-        Opal.defn(self, 'render', function(prev) {
-          var self = this;
-
-          if(prev && prev.vnode && #{!should_render?(`prev`)}) {
-            return prev.vnode;
-          } else {
-            var content = #{Component.sanitize_content(render)};
-
-            while(content && content.type == 'Thunk' && content.render) {
-              content = #{Component.sanitize_content(`content.render(prev)`)};
-            }
-
-            return content;
-          }
-        });
+        Opal.defn(self, '$$cached_render', true);
       }
     end
 
     def should_render? _
       false
+    end
+
+    def key
+      `undefined`
     end
   end
 end

--- a/opal/clearwater/cached_render/wrapper.rb
+++ b/opal/clearwater/cached_render/wrapper.rb
@@ -1,0 +1,32 @@
+module Clearwater
+  module CachedRender
+    class Wrapper
+      attr_reader :content
+
+      def initialize content
+        @content = content
+        @key = content.key
+      end
+
+      # Hook into vdom diff/patch
+      %x{
+        def.type = 'Thunk';
+        def.render = function cached_render(prev) {
+          var self = this;
+
+          if(prev && prev.vnode && #{!@content.should_render?(`prev.content`)}) {
+            return prev.vnode;
+          } else {
+            var content = #{Component.sanitize_content(@content.render)};
+
+            while(content && content.type == 'Thunk' && content.render) {
+              content = #{Component.sanitize_content(`content.render(prev)`)};
+            }
+
+            return content;
+          }
+        };
+      }
+    end
+  end
+end


### PR DESCRIPTION
This keeps the component from being injected with virtual-DOM logic. It can simply be its own Ruby object. The wrapper acts as an adapter between the two.

There are two main benefits of this:
- You can now have a `@type` instance variable. Previously, if you defined one in your component, it would prevent the virtual-DOM engine from caching it.
- You can define a `key` method on your component to optimize diffing/patching when child nodes are moved around or deleted. Previously, you either had to wrap the component in a container node with a `key` property (slower because it would have to be diffed without hints) or set an `@key` instance variable (completely unintuitive in Ruby).

The downside of this is that it allocates an additional object for each cached component on every render, but I haven't seen this cause any negative effect on realistic performance. Even in my contrived app that renders (among other things) 1000 cached list items, performance _improved_ (from 9ms to 4.5ms per render) with no noticeable difference in memory usage.

Posting a PR in case there's something I may be missing. Render caching is pretty important for Clearwater so I don't want to screw it up. :-)