### PR TITLE
Components rendering an array should generate HTML

### DIFF
--- a/lib/clearwater/component.rb
+++ b/lib/clearwater/component.rb
@@ -27,7 +27,7 @@ module Clearwater
     end
 
     def to_s
-      html = Array(render).map(&:to_s).join
+      html = Array(render).join
       html.respond_to?(:html_safe) ? html.html_safe : html
     end
 

--- a/lib/clearwater/component.rb
+++ b/lib/clearwater/component.rb
@@ -27,12 +27,8 @@ module Clearwater
     end
 
     def to_s
-      content = Array(render).map do |node|
-        html = node.to_s
-        html.respond_to?(:html_safe) ? html.html_safe : html
-      end
-
-      content.join
+      html = Array(render).map(&:to_s).join
+      html.respond_to?(:html_safe) ? html.html_safe : html
     end
 
     def params

--- a/lib/clearwater/component.rb
+++ b/lib/clearwater/component.rb
@@ -27,12 +27,12 @@ module Clearwater
     end
 
     def to_s
-      html = render.to_s
-      if html.respond_to? :html_safe
-        html = html.html_safe
+      content = Array(render).map do |node|
+        html = node.to_s
+        html.respond_to?(:html_safe) ? html.html_safe : html
       end
 
-      html
+      content.join
     end
 
     def params

--- a/spec/clearwater/component_spec.rb
+++ b/spec/clearwater/component_spec.rb
@@ -13,6 +13,17 @@ module Clearwater
       expect(html).to eq('<div id="foo" class="bar"><p>baz</p></div>')
     end
 
+    it 'generates html for components rendering an array' do
+      component_class = Class.new do
+        include Clearwater::Component
+
+        def render
+          [ div({}, "1"), div({}, "2") ]
+        end
+      end
+      expect(component_class.new.to_s).to eq('<div>1</div><div>2</div>')
+    end
+
     it 'converts styles into strings' do
       html = component.div({
         style: {


### PR DESCRIPTION
Calling `to_s` directly on the returned value of a component's `render` method breaks components that render an array of components. Instead you get the output of the array's `inspect` method.