### PR TITLE
Differed init + update + lifecycle 'hooks'

### DIFF
--- a/shared/clearwater/sticky_component.rb
+++ b/shared/clearwater/sticky_component.rb
@@ -1,79 +1,44 @@
 require 'clearwater/component'
-require 'clearwater/black_box_node'
 
 module Clearwater
   class StickyComponent
     include Clearwater::Component
 
-    attr_accessor :props, :renderer
-    attr_reader :children
-
-    def self.render props=nil, children=nil
-      unless `props === nil || props.$$is_hash`
-        children = props
-        props = nil
+    class << self
+      alias_method :_new, :new
+      def new(*args)
+        Wrapper.new(*args) { |*arguments| _new(*arguments) }
       end
-
-      Wrapper2.new(self, props, children)
     end
 
-    def initialize(props=nil, children=nil)
-      @props = self.class.make_props props
-      @children = children
-    end
-
-    def should_update? next_props
+    def should_update?(*args)
       true
     end
 
-    def component klass, props=nil, children=nil
-      klass.render props, children
+    def update(*args)
     end
 
-    def will_receive_props props
+    def before_update
     end
 
-    def will_update props
+    def after_update
     end
 
-    def did_update old_props
+    def before_mount
     end
 
-    def will_mount
+    def after_mount
     end
 
-    def did_mount
-    end
-
-    def will_unmount
-    end
-
-    def call &block
-      if renderer
-        renderer.update_dom(&block)
-      else
-        Clearwater::Application.render(&block)
-      end
-    end
-
-    def self.make_props props
-      if `props.$$is_hash`
-        Props.new(props)
-      elsif props.nil?
-        Props.new
-      else
-        props
-      end
+    def before_unmount
     end
 
     class Wrapper
       attr_reader :component
 
-      def initialize klass, props=nil, children=nil
-        @klass = klass
-        @props = StickyComponent.make_props props
-        @children = children
-        @key = @props.key if @props.key
+      def initialize(*args, &block)
+        @args = args
+        @block = block
       end
 
       %x{
@@ -87,123 +52,23 @@ module Clearwater
              previous.component) {
             self.component = previous.component;
 
-            #{component.will_receive_props @props};
-            if(#{component.should_update?(@props)}) {
-              #{component.will_update @props};
-
-              var old_props = #{component}.props;
-              #{component}.props = #@props;
-
-              #{Bowser.window.animation_frame { component.did_update `old_props` }};
-
+            if(#{component.should_update?(*@args)}) {
+              #{component.before_update};
+              #{component.update(*@args)};
+              #{Bowser.window.animation_frame { component.after_update }};
               return #{component.render};
             }
 
             return previous.vnode;
           } else {
-            self.component = #{@klass.new(@props, @children)};
-            #{component.will_receive_props @props};
+            self.component = #{@block.call(*@args)};
+            #{component.before_mount};
+            #{Bowser.window.animation_frame { component.after_mount }};
 
-            #{component.will_mount};
-            #{Bowser.window.animation_frame { component.did_mount }};
             return #{component.render};
           }
         });
       }
-    end
-
-    class Wrapper2
-      include Clearwater::BlackBoxNode
-
-      attr_reader :component, :props, :vdom
-
-      def initialize klass, props=nil, children=nil
-        @klass = klass
-        @props = StickyComponent.make_props props
-        @children = children
-        @key = @props.key if @props.key
-      end
-
-      # Called once before mount, never called again for this component.
-      def node
-        @component = @klass.new(@props, @children, &@block)
-        @component.will_mount
-        @node = sanitize_component
-      end
-
-      def mount element
-        @vdom = Clearwater::VirtualDOM::Document.new(element)
-
-        # Prime the vdom so it doesn't try to render from scratch.
-        `#@vdom.node = #{@node}`
-        `#@vdom.tree = #{element.to_n}`
-        `#@vdom.rendered = true`
-
-        Bowser.window.animation_frame { component.did_mount element }
-        component.renderer = self
-      end
-
-      def update previous, element
-        @component = previous.component
-        @vdom = previous.vdom
-        component.will_receive_props props
-
-        return unless component.should_update? props
-
-        old_props = previous.props
-        component.props = props
-
-        if !component.props.async_render
-          component.will_update props
-          update_dom
-        end
-
-        Bowser.window.animation_frame do
-          if component.props.async_render
-            component.will_update props
-            update_dom
-          end
-
-          component.did_update old_props
-        end
-        component.renderer = self
-      end
-
-      def unmount previous
-        component.will_unmount
-      end
-
-      def update_dom(&block)
-        @vdom.render sanitize_component
-        block.call if block_given?
-      end
-
-      def sanitize_component
-        Clearwater::Component.sanitize_content(component)
-      end
-    end
-
-    class Props
-      def initialize props={}
-        @props = props
-      end
-
-      def merge other
-        @props.merge(other)
-      end
-
-      def method_missing message, *args
-        # We only support fetching props, and extra args mean a method call.
-        if args.empty?
-          @props[message]
-        else
-          super
-        end
-      end
-
-      def to_s
-        @props.to_s
-      end
     end
   end
 end

--- a/shared/clearwater/sticky_component.rb
+++ b/shared/clearwater/sticky_component.rb
@@ -11,6 +11,10 @@ module Clearwater
       end
     end
 
+    def initialize(*args)
+      update(*args)
+    end
+
     def should_update?(*args)
       true
     end

--- a/shared/clearwater/sticky_component.rb
+++ b/shared/clearwater/sticky_component.rb
@@ -22,21 +22,6 @@ module Clearwater
     def update(*args)
     end
 
-    def before_update
-    end
-
-    def after_update
-    end
-
-    def before_mount
-    end
-
-    def after_mount
-    end
-
-    def before_unmount
-    end
-
     class Wrapper
       attr_reader :component
 
@@ -57,18 +42,13 @@ module Clearwater
             self.component = previous.component;
 
             if(#{component.should_update?(*@args)}) {
-              #{component.before_update};
               #{component.update(*@args)};
-              #{Bowser.window.animation_frame { component.after_update }};
               return #{component.render};
             }
 
             return previous.vnode;
           } else {
             self.component = #{@block.call(*@args)};
-            #{component.before_mount};
-            #{Bowser.window.animation_frame { component.after_mount }};
-
             return #{component.render};
           }
         });


### PR DESCRIPTION
I spent some time thinking about the approaches and discussion in #70 and came up with this. It still suffers from some tradeoffs (possibly two places dealing with passed in args), but for me feels a bit closer to the "right" abstraction.

In this implementation of `StickyComponent`:

* `initialize` is called only once per instance with the arguments given to `new`.
* There is an `update` method that receives args for subsequent renders. This is the formal place to operate on passed in properties.
* By default, `initialize` delegates to `update` to avoid duplication, but can easily be overridden.
* The `will_` and `did_` methods are replaced with 'hooks'. I don't see any reason for these to be passed arguments since they'll be the same values until the next render. I do, however, find it useful to be able to hook into various stages of the lifecycle. For example, `before_update` would be to save current state before it is replaced instead of adding additional logic to the `update` method.